### PR TITLE
Fix typos; MathML -> MathJAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This version has been thoroughly cleaned of artifacts and condensed into somethi
 
 Changes are welcome, especially conversion-related ones. If you spot any problems while reading, please [submit an issue](https://github.com/jagregory/abrash-black-book/issues) and I'll correct it. Pull Requests are always welcome.
 
-Some larger changes could be made to improve the content. I'd love to see some of the images converted to a vector representation so we can provide higher-resolution versions.  Formulas and equations could be typeset with MathML.
+Some larger changes could be made to improve the content. I'd love to see some of the images converted to a vector representation so we can provide higher-resolution versions.  Formulas and equations could be typeset with [MathJax](http://www.mathjax.org/).
 
 ## Generating your own ebook
 


### PR DESCRIPTION
AFAIK MathML is a dinosaur that nobody uses, and MathJAX is the preferred mathematical typesetting technology for the web.  For ebooks I'm not sure what the best choice is, but I am sure that MathML isn't the answer.

If you disagree with my stance on MathJAX vs. MathML, but still want my spelling/grammar improvements, feel free to just pull the first of these two commits.
