### PR TITLE
Correct typos in listing 3.1

### DIFF
--- a/src/chapter-03.md
+++ b/src/chapter-03.md
@@ -2075,23 +2075,23 @@ the precision Zen timer to handle on the 8088.
 ; Note: takes about ten minutes to assemble on a slow PC if
 ;you are using MASM
 ;
-jmpSkip;jump around defined data
+    jmp     Skip ;jump around defined data
 ;
-MemVardb?
+MemVar  db  ?
 ;
 Skip:
 ;
 ; Start timing.
 ;
-callZTimerOn
+    call   ZTimerOn
 ;
-rept20000
-moval,[MemVar]
-endm
+    rept   20000
+    mov    al,[MemVar]
+    endm
 ;
 ; Stop timing.
 ;
-callZTimerOff
+    call   ZTimerOff
 ```
 
 When LZTIME.BAT is run on a PC with the following command line (assuming

--- a/src/chapter-03.md
+++ b/src/chapter-03.md
@@ -1932,25 +1932,25 @@ timing.
 ;
 ; By Michael Abrash
 ;
-mystack   segment    para stack ‘STACK'
+mystack   segment    para stack 'STACK'
      db         512 dup(?)
-mystack    ends
+mystack   ends
 ;
-Code  segment   para public ‘CODE'
+Code  segment   para public 'CODE'
       assume    cs:Code, ds:Code
-      extrn ZTimerOn:near, ZTimerOff:near, ZTimerReport:near
-Startproc   near
-      push  cs
-     pop    ds     ;point DS to the code segment,
+      extrn     ZTimerOn:near, ZTimerOff:near, ZTimerReport:near
+Start proc near
+     push  cs
+     pop   ds      ;point DS to the code segment,
                    ; so data as well as code can easily
                    ; be included in TESTCODE
 ;
 ; Delay for 6-7 seconds, to let the Enter keystroke that started the
 ; program come back up.
 ;
-     mov  ah,2ch
-     int  21h        ;get the current time
-     mov  bh,dh      ;set the current time aside
+     mov   ah,2ch
+     int   21h                ;get the current time
+     mov   bh,dh              ;set the current time aside
 DelayLoop:
      mov   ah,2ch
      push  bx                 ;preserve start time
@@ -1962,12 +1962,12 @@ DelayLoop:
      add   dh,60              ;yes, a minute must have turned over,
                               ; so add one minute
 CheckDelayTime:
-     sub   dh,bh                 ;get time that's passed
-     cmp   dh,7                  ;has it been more than 6 seconds yet?
-     jb    DelayLoop             ;not yet
+     sub   dh,bh              ;get time that's passed
+     cmp   dh,7               ;has it been more than 6 seconds yet?
+     jb    DelayLoop          ;not yet
 ;
-     include   TESTCODE          ;code to be measured, including calls
-                                 ; to ZTimerOn and ZTimerOff
+     include   TESTCODE       ;code to be measured, including calls
+                              ; to ZTimerOn and ZTimerOff
 ;
 ; Display the results.
 ;
@@ -1975,8 +1975,8 @@ CheckDelayTime:
 ;
 ; Terminate the program.
 ;
-     mov  ah,4ch
-     int  21h
+     mov   ah,4ch
+     int   21h
 Start endp
 Code  ends
       end     Start

--- a/src/chapter-03.md
+++ b/src/chapter-03.md
@@ -913,13 +913,13 @@ and should contain calls to `ZTimerOn` and `ZTimerOff` .
 ;
 ; By Michael Abrash
 ;
-mystack   segment  para stack ‘STACK'
+mystack   segment  para stack 'STACK'
       db  512 dup(?)
 mystack   ends
 ;
-Code  segment   para public ‘CODE'
+Code  segment   para public 'CODE'
       assume    cs:Code, ds:Code
-      extrnZTimerOn:near, ZTimerOff:near, ZTimerReport:near
+      extrn     ZTimerOn:near, ZTimerOff:near, ZTimerReport:near
 Start proc near
       push cs
       pop  ds    ; set DS to point to the code segment,

--- a/src/chapter-03.md
+++ b/src/chapter-03.md
@@ -163,34 +163,34 @@ presented in Chapter K on the companion CD-ROM.
 ; in when ZTimerOn was called.
 ;
 
-Code segment word public ‘CODE'
-     assumecs:    Code, ds:nothing
+Code segment word public 'CODE'
+     assume       cs:Code, ds:nothing
      public       ZTimerOn, ZTimerOff, ZTimerReport
 
 ;
 ; Base address of the 8253 timer chip.
 ;
-BASE_8253equ40h
+BASE_8253        equ 40h
 ;
 ; The address of the timer 0 count registers in the 8253.
 ;
-TIMER_0_8253     equBASE_8253 + 0
+TIMER_0_8253     equ BASE_8253 + 0
 ;
 ; The address of the mode register in the 8253.
 ;
-MODE_8253        equBASE_8253 + 3
+MODE_8253        equ BASE_8253 + 3
 ;
 ; The address of Operation Command Word 3 in the 8259 Programmable
 ; Interrupt Controller (PIC) (write only, and writable only when
 ; bit 4 of the byte written to this address is 0 and bit 3 is 1).
 ;
-OCW3              equ20h
+OCW3              equ 20h
 ;
 ; The address of the Interrupt Request register in the 8259 PIC
 ; (read only, and readable only when bit 1 of OCW3 = 1 and bit 0
 ; of OCW3 = 0).
 ;
-IRR               equ20h
+IRR               equ 20h
 ;
 ; Macro to emulate a POPF instruction in order to fix the bug in some
 ; 80286 chips which allows interrupts to occur during a POPF even when
@@ -220,7 +220,7 @@ OriginalFlags   db    ?    ; storage for upper byte of
                            ; ZTimerOn called
 TimedCount      dw    ?    ; timer 0 count when the timer
                            ; is stopped
-ReferenceCount  dw         ; number of counts required to
+ReferenceCount  dw    ?    ; number of counts required to
                            ; execute timer overhead code
 OverflowFlag    db    ?    ; used to indicate whether the
                            ; timer overflowed during the
@@ -229,28 +229,28 @@ OverflowFlag    db    ?    ; used to indicate whether the
 ; String printed to report results.
 ;
 OutputStr  label byte
-           db    0dh, 0ah, ‘Timed count: ‘, 5 dup (?)
-ASCIICountEnd    labelbyte
-           db    ‘ microseconds', 0dh, 0ah
-           db    ‘$'
+           db    0dh, 0ah, 'Timed count: ', 5 dup (?)
+ASCIICountEnd    label byte
+           db    ' microseconds', 0dh, 0ah
+           db    '$'
 ;
 ; String printed to report timer overflow.
 ;
 OverflowStr label byte
       db    0dh, 0ah
-      db    ‘****************************************************'
+      db    '****************************************************'
       db    0dh, 0ah
-      db    ‘* The timer overflowed, so the interval timed was  *'
+      db    '* The timer overflowed, so the interval timed was  *'
       db    0dh, 0ah
-      db    ‘* too long for the precision timer to measure.     *'
+      db    '* too long for the precision timer to measure.     *'
       db    0dh, 0ah
-      db    ‘* Please perform the timing test again with the    *'
-db0dh, 0ah
-      db    ‘* long-period timer.                               *'    
+      db    '* Please perform the timing test again with the    *'
       db    0dh, 0ah
-      db    ‘****************************************************'
+      db    '* long-period timer.                               *'
       db    0dh, 0ah
-      db    ‘$'
+      db    '****************************************************'
+      db    0dh, 0ah
+      db    '$'
 
 ; ********************************************************************
 ; * Routine called to start timing.                                  *
@@ -418,7 +418,7 @@ ZTimerOff  endp
 ; Called by ZTimerOff to start timer for overhead measurements.
 ;
 
-ReferenceZTimerOnproc   near
+ReferenceZTimerOn proc  near
 ;
 ; Save the context of the program being timed.
 ;
@@ -445,7 +445,7 @@ ReferenceZTimerOnproc   near
      pop    ax
      ret
 
-ReferenceZTimerOnendp
+ReferenceZTimerOn endp
 
 ;
 ; Called by ZTimerOff to stop timer and add result to ReferenceCount
@@ -488,7 +488,7 @@ ReferenceZTimerOff endp
 ; * Routine called to report timing results.                         *
 ; ********************************************************************
 
-ZTimerReport procnear
+ZTimerReport proc    near
 
        pushf
        push  ax
@@ -541,7 +541,7 @@ CTSLoop:
 ;
      mov   ah, 9
      mov   dx, offset OutputStr
-     int   21h 
+     int   21h
 ;
 EndZTimerReport:
      pop   ds
@@ -2190,7 +2190,7 @@ call     near ptr ReferenceZTimerOn
 (and likewise for `ReferenceZTimerOff`), which works because
 `ReferenceZTimerOn` is in the same segment as the calling code. This
 is normally a great optimization, being both smaller and faster than a
-far call. 
+far call.
 
 ![**Figure 3.3**  *Changes for use with large code model C.*](images/03-03.jpg)
 


### PR DESCRIPTION
I found some typos in a number of the chapter 3 code listings.  I made the necessary corrections such that MASM 6.11 successfully assembles the code.
