### PR TITLE
Add .gitignore, fix table width and hide code scrollbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Output directory
+out

--- a/html/book.css
+++ b/html/book.css
@@ -54,8 +54,8 @@ figure {
 }
 
 pre, table {
-  overflow: scroll;
-  width: 100%;
+  overflow: hidden;
+  width: 100% !important;
 }
 
 caption {


### PR DESCRIPTION
These days I `make html`-ed the book and exported PDF file using Chrome's `Print...` and found that the widths of table were overridden by the `style` attribute in element tags, where the widths were beyond `100%`. Without reading the further and deeper codes of the generator, I added `!important` suffix to fix the width.

``` css
pre, table {
  overflow: hidden;
  width: 100% !important;
}
```
- To some extent it might be a little rude to use this but it works just fine at present
- Apart from this, I used `hidden` overflow for disabling the scrollbars, because I exported PDF via Chrome where the scrollbars were included and it felt weird if self-printed as paperback (or something else)
- And, I added `.gitignore` for ignoring output directory which can be distributed
