### PR TITLE
Replace Pandoc -S switch with +smart extension and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ all: html epub mobi
 html:
 	rm -rf out/html && mkdir -p out/html
 	cp -r images html/book.css out/html/
-	pandoc -S --to html5 -o out/html/black-book.html --section-divs --toc --standalone --template=html/template.html $(FILES)
+	pandoc --to html5+smart -o out/html/black-book.html --section-divs --toc --standalone --template=html/template.html $(FILES)
 
 epub:
 	mkdir -p out
 	rm -f out/black-book.epub
-	pandoc -S --to epub3 -o out/black-book.epub --epub-cover-image images/cover.png --toc --epub-chapter-level=2 --data-dir=epub --template=epub/template.html $(FILES)
+	pandoc --to epub3+smart -o out/black-book.epub --epub-cover-image images/cover.png --toc --epub-chapter-level=2 --data-dir=epub --template=epub/template.html $(FILES)
 
 mobi:
 	rm -f out/black-book.mobi

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some larger changes could be made to improve the content. I'd love to see some o
 
 You need to have the following software installed and on your `PATH` before you begin:
 
-  * [pandoc](http://johnmacfarlane.net/pandoc/) for Markdown to HTML and Epub conversion.
+  * [pandoc](http://johnmacfarlane.net/pandoc/) version 2.0 or greater for Markdown to HTML and Epub conversion.
   * [kindlegen](http://www.amazon.com/gp/feature.html?docId=1000765211) for Epub to Mobi conversion.
 
 To generate an e-reader friendly version of the book, you can use `make` with one of the following options:


### PR DESCRIPTION
The -S switch no longer works on the current version of Pandoc.  This fixes the Makefile by replacing the -S Pandoc switch with Pandoc's newer +smart extension.  It also updates `README.md` to specify Pandoc version 2.0 or greater.

This fixes issue #36 and supersedes pull request #31.