### PR TITLE
Adjust Makefile so it will work with pandoc 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ all: html epub mobi
 html:
 	rm -rf out/html && mkdir -p out/html
 	cp -r images html/book.css out/html/
-	pandoc -S --to html5 -o out/html/black-book.html --section-divs --toc --standalone --template=html/template.html $(FILES)
+	pandoc --from=markdown+smart --to html5 -o out/html/black-book.html --section-divs --toc --standalone --template=html/template.html $(FILES)
 
 epub:
 	mkdir -p out
 	rm -f out/black-book.epub
-	pandoc -S --to epub3 -o out/black-book.epub --epub-cover-image images/cover.png --toc --epub-chapter-level=2 --data-dir=epub --template=epub/template.html $(FILES)
+	pandoc --from=markdown+smart --to epub3 -o out/black-book.epub --epub-cover-image images/cover.png --toc --epub-chapter-level=2 --data-dir=epub --template=epub/template.html $(FILES)
 
 mobi:
 	rm -f out/black-book.mobi


### PR DESCRIPTION
In the new major version of pandoc (2.0) the flags --smart/-S
have been removed. For this version the +smart or -smart extension
needs to be used instead.