### PR TITLE
Replace ‘ with ' in code examples

### DIFF
--- a/src/chapter-07.md
+++ b/src/chapter-07.md
@@ -246,21 +246,21 @@ the whole point.)
         .data
 ; Sample string to search through.
 SampleString        label byte
-        db   ‘This is a sample string of a long enough length '
-        db   ‘so that raw searching speed can outweigh any '
-        db   ‘extra set-up time that may be required.',0
+        db   'This is a sample string of a long enough length '
+        db   'so that raw searching speed can outweigh any '
+        db   'extra set-up time that may be required.',0
 SAMPLE_STRING_LENGTH  equ  $-SampleString
 
 ; User prompt.
-Prompt     db      ‘Enter character to search for:$'
+Prompt     db      'Enter character to search for:$'
 
 ; Result status messages.
 ByteFoundMsg         db    0dh,0ah
-                     db    ‘Specified byte found.',0dh,0ah,‘$'
+                     db    'Specified byte found.',0dh,0ah,'$'
 ZeroByteFoundMsg db  0dh, 0ah
-                     db    ‘Zero byte encountered.',0dh,0ah,‘$'
+                     db    'Zero byte encountered.',0dh,0ah,'$'
 NoByteFoundMsg       db    0dh,0ah
-                     db    ‘Buffer exhausted with no match.', 0dh, 0ah, ‘$'
+                     db    'Buffer exhausted with no match.', 0dh, 0ah, '$'
 
     .code
 Start proc near
@@ -351,21 +351,21 @@ all the difference.
        .data
 ; Sample string to search through.
 SampleString label byte
-        db     ‘This is a sample string of a long enough length '
-        db     ‘so that raw searching speed can outweigh any '
-        db     ‘extra set-up time that may be required.',0
+        db     'This is a sample string of a long enough length '
+        db     'so that raw searching speed can outweigh any '
+        db     'extra set-up time that may be required.',0
 SAMPLE_STRING_LENGTH  equ  $-SampleString
 
 ; User prompt.
-Prompt  db        ‘Enter character to search for:$'
+Prompt  db        'Enter character to search for:$'
 
 ; Result status messages.
 ByteFoundMsg          db      0dh,0ah
-                      db      ‘Specified byte found.',0dh,0ah,‘$'
+                      db      'Specified byte found.',0dh,0ah,'$'
 ZeroByteFoundMsg db   0dh,0ah
-                      db      ‘Zero byte encountered.', 0dh, 0ah, ‘$'
+                      db      'Zero byte encountered.', 0dh, 0ah, '$'
 NoByteFoundMsg        db      0dh,0ah
-                      db      ‘Buffer exhausted with no match.', 0dh, 0ah, ‘$'
+                      db      'Buffer exhausted with no match.', 0dh, 0ah, '$'
 
 ; Table of initial, possibly partial loop entry points for
 ; SearchMaxLength.

--- a/src/chapter-16.md
+++ b/src/chapter-16.md
@@ -155,10 +155,10 @@ timed from a RAM disk on a 20 MHz 386.
           Ch = *BufferPtr++ & 0x7F; /* strip high bit, which some
                                        word processors set as an
                                        internal flag */
-          CharFlag = ((Ch >= ‘a') && (Ch <= ‘z')) ||
-                     ((Ch >= ‘A') && (Ch <= ‘Z')) ||
-                     ((Ch >= ‘0') && (Ch <= ‘9')) ||
-                     (Ch == ‘\'');
+          CharFlag = ((Ch >= 'a') && (Ch <= 'z')) ||
+                     ((Ch >= 'A') && (Ch <= 'Z')) ||
+                     ((Ch >= '0') && (Ch <= '9')) ||
+                     (Ch == '\'');
           if ((!CharFlag) && PredCharFlag) {
              WordCo u nt++; 
           }
@@ -291,19 +291,19 @@ ScanLoop:
         and     al,7fh          ;strip high bit for word processors
                                 ; that set it as an internal flag
         mov     bl,1            ;assume this is a char; CharFlag = 1;
-        cmp     al,‘a'          ;it is a char if between a and z
+        cmp     al,'a'          ;it is a char if between a and z
         jb      CheckAZ
-        cmp     al,‘z'
+        cmp     al,'z'
         jna     IsAChar
 CheckAZ:
-        cmp     al,‘A'          ;it is a char if between A and Z
+        cmp     al,'A'          ;it is a char if between A and Z
         jb      Check09
-        cmp     al,‘Z'
+        cmp     al,'Z'
         jna     IsAChar
 Check09:
-        cmp     al,‘0'          ;it is a char if between 0 and 9
+        cmp     al,'0'          ;it is a char if between 0 and 9
         jb      CheckApostrophe
-        cmp     al,‘9'
+        cmp     al,'9'
         jna     IsAChar
 CheckApostrophe:
         cmp      al,27h           ;it is a char if an apostrophe 
@@ -745,7 +745,7 @@ jumping.
                  mov     di,[bp+CharFlag]
                  mov     bh,[di]             ;bh = old CharFlag
                  mov     bl,[si]             ;bl = character
-                 add     bh,‘A'-1            ;make bh into character
+                 add     bh,'A'-1            ;make bh into character
                  add     bx,bx               ;prepare to index
                  mov     al,es:[bx]
                  cbw                         ;get hi bit in ah (then bh)
@@ -1155,7 +1155,7 @@ report a "location counter overflow" warning; ignore it.)
 #include <stdio.h>
 #include <ctype.h>
  
-#define ChType( c )  (((c) & 0x7f) == ‘\'' || isalnum((c) & 0x7f))
+#define ChType( c )  (((c) & 0x7f) == '\'' || isalnum((c) & 0x7f))
  
 int NoCarry[ 4 ] = { 0, 0x80, 1, 0x80 };
 int Carry[ 4 ]   = { 1, 0x81, 1, 0x80 };

--- a/src/chapter-18.md
+++ b/src/chapter-18.md
@@ -249,7 +249,7 @@ void BuildMaps( void )
   {
   unsigned short i, j, Size, x = 0, y, N1, N2, N3, C1, C2, C3;
 
-  printf( "_DATA segment ‘DATA'\nalign 2\n" );
+  printf( "_DATA segment 'DATA'\nalign 2\n" );
   printf( "public _CellMap\n" );
   printf( "_CellMap label word\n" );
 
@@ -284,7 +284,7 @@ void BuildMaps( void )
     printf( "Change1 dw offset _CHANGE:_ChangeList1\n" );
     printf( "Change2 dw offset _CHANGE:_ChangeList2\n" );
     printf( "ends\n\n" );
-    printf( "_CHANGE segment para public ‘FAR_DATA'\n" );
+    printf( "_CHANGE segment para public 'FAR_DATA'\n" );
     }
   else
     {
@@ -300,7 +300,7 @@ void BuildMaps( void )
   printf( "dw %d dup (offset DGROUP:ChangeCell)\n", Size );
   printf( "ends\n\n" );
 
-  printf( "_LDMAP segment para public ‘FAR_DATA'\n" );
+  printf( "_LDMAP segment para public 'FAR_DATA'\n" );
 
   do
     {
@@ -536,7 +536,7 @@ void Fix( char *Offset, char *Str, int JumpBack )
   printf( "mov  bh,[bx]\n" );
   printf( "mov  [bp+%s],bx\n", Offset );
 
-  if( *Offset != ‘0' )  printf( "lea  ax,[bp+%s]\n", Offset );
+  if( *Offset != '0' )  printf( "lea  ax,[bp+%s]\n", Offset );
   else                  printf( "mov  ax,bp\n" );
 
   printf( "stosw\n" );
@@ -654,7 +654,7 @@ void main( void )
   BuildMaps();
 
   printf( "DGROUP group _DATA\n" );
-  printf( "LIFE segment ‘CODE'\n" );
+  printf( "LIFE segment 'CODE'\n" );
   printf( "assume cs:LIFE,ds:DGROUP,ss:DGROUP,es:NOTHING\n" );
   printf( ".386C\n" "public _NextGen\n\n" );
 

--- a/src/chapter-24.md
+++ b/src/chapter-24.md
@@ -126,7 +126,7 @@ only the enabled planes would be affected by each operation.
 ;  the images with the background.
 ; By Michael Abrash.
 ;
-stack   segment para stack ‘STACK'
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -149,23 +149,23 @@ GC_ROTATE       equ     3       ;GC data rotate/logical function
                                 ; register index
 GC_MODE         equ     5       ;GC mode register index
 ;
-dseg    segment para common ‘DATA'
+dseg    segment para common 'DATA'
 ;
 ; String used to label logical functions.
 ;
 LabelString     label   byte
-        db      ‘UNMODIFIED    AND       OR        XOR   '
+        db      'UNMODIFIED    AND       OR        XOR   '
 LABEL_STRING_LENGTH     equ     $-LabelString
 ;
 ; Strings used to label fill patterns.
 ;
-FillPatternFF   db      ‘Fill Pattern: 0FFh'
+FillPatternFF   db      'Fill Pattern: 0FFh'
 FILL_PATTERN_FF_LENGTH  equ     $ - FillPatternFF
-FillPattern00   db      ‘Fill Pattern: 000h'
+FillPattern00   db      'Fill Pattern: 000h'
 FILL_PATTERN_00_LENGTH  equ     $ - FillPattern00
-FillPatternVert db      ‘Fill Pattern: Vertical Bar'
+FillPatternVert db      'Fill Pattern: Vertical Bar'
 FILL_PATTERN_VERT_LENGTH        equ     $ - FillPatternVert
-FillPatternHorz db      ‘Fill Pattern: Horizontal Bar'
+FillPatternHorz db      'Fill Pattern: Horizontal Bar'
 FILL_PATTERN_HORZ_LENGTH equ    $ - FillPatternHorz
 ;
 dseg    ends
@@ -192,7 +192,7 @@ TEXT_UP macro   TEXT_STRING, TEXT_LENGTH, ROW, COLUMN
         int     10h
         endm
 ;
-cseg    segment para public ‘CODE'
+cseg    segment para public 'CODE'
         assume  cs:cseg, ds:dseg
 start   proc    near
         mov     ax,dseg

--- a/src/chapter-25.md
+++ b/src/chapter-25.md
@@ -112,7 +112,7 @@ BIOS, as well).
 ;  for use with modes 0Dh, 0Eh, 0Fh, 10h, and 12h.
 ; By Michael Abrash.
 ;
-stack   segment para stack ‘STACK'
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -127,13 +127,13 @@ GC_ROTATE       equ     3       ;GC data rotate/logical function
                                 ; register index
 GC_BIT_MASK     equ     8       ;GC bit mask register index
 ;
-dseg    segment para common ‘DATA'
+dseg    segment para common 'DATA'
 TEST_TEXT_ROW   equ     69      ;row to display test text at
 TEST_TEXT_COL   equ     17      ;column to display test text at
 TEST_TEXT_WIDTH equ     8       ;width of a character in pixels
 
 TestString      label   byte
-        db      ‘Hello, world!',0       ;test string to print.
+        db      'Hello, world!',0       ;test string to print.
 FontPointer     dd      ?               ;font offset
 dseg    ends
 ;
@@ -145,7 +145,7 @@ SETGC   macro   INDEX, SETTING
         out     dx,ax
         endm
 ;
-cseg    segment para public ‘CODE'
+cseg    segment para public 'CODE'
         assume  cs:cseg, ds:dseg
 start   proc    near
         mov     ax,dseg
@@ -452,7 +452,7 @@ set the Map Mask register to 01H and fill with blue.
 ;  to memory that already contains data.
 ; By Michael Abrash.
 ;
-stack   segment para stack ‘STACK'
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -475,7 +475,7 @@ SETSC   macro   INDEX, SETTING
         dec     dx
         endm
 ;
-cseg    segment para public ‘CODE#146;
+cseg    segment para public 'CODE'
         assume  cs:cseg
 start   proc    near
 ;
@@ -575,7 +575,7 @@ off as well as 0FFH-bytes to planes that must be on.
 ;  setting of memory that already contains data.
 ; By Michael Abrash.
 ;
-stack   segment para stack ‘STACK#146;
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -613,7 +613,7 @@ SETGC   macro   INDEX, SETTING
         dec     dx
         endm
 ;
-cseg    segment para public ‘CODE#146;
+cseg    segment para public 'CODE'
         assume  cs:cseg
 start   proc    near
 ;
@@ -639,8 +639,8 @@ HorzBarLoop:
         dec     bp
         jnz     HorzBarLoop
 ;
-; Fill screen with blue, using set/reset to force plane 0 to 1#146;s and all
-; other plane to 0#146;s.
+; Fill screen with blue, using set/reset to force plane 0 to 1's and all
+; other plane to 0's.
 ;
         SETSC   SC_MAP_MASK,0fh         ;must set map mask to enable all
                                         ; planes, so set/reset values can
@@ -707,7 +707,7 @@ be used to control individual pixels.
 ;  with CPU data to modify setting of memory that already contains data.
 ; By Michael Abrash.
 ;
-stack   segment para stack ‘STACK#146;
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -745,7 +745,7 @@ SETGC   macro   INDEX, SETTING
         dec     dx
         endm
 ;
-cseg    segment para public ‘CODE#146;
+cseg    segment para public 'CODE'
         assume  cs:cseg
 start   proc    near
 ;

--- a/src/chapter-26.md
+++ b/src/chapter-26.md
@@ -91,7 +91,7 @@ characters can be drawn in any of the 16 available colors.
 ; Assembled with MASM
 ; By Michael Abrash
 ;
-stack   segment para stack ‘STACK'
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -111,16 +111,16 @@ GC_ROTATE       equ     3       ;GC data rotate/logical function
 GC_MODE         equ     5       ;GC Mode register
 GC_BIT_MASK     equ     8       ;GC bit mask register index
 ;
-dseg    segment para common ‘DATA'
+dseg    segment para common 'DATA'
 TEST_TEXT_ROW   equ     69      ;row to display test text at
 TEST_TEXT_COL   equ     17      ;column to display test text at
 TEST_TEXT_WIDTH equ     8       ;width of a character in pixels
 TestString      label   byte
-        db      ‘Hello, world!',0       ;test string to print.
+        db      'Hello, world!',0       ;test string to print.
 FontPointer     dd      ?               ;font offset
 dseg    ends
 ;
-cseg    segment para public ‘CODE'
+cseg    segment para public 'CODE'
         assume  cs:cseg, ds:dseg
 start   proc    near
         mov     ax,dseg
@@ -458,7 +458,7 @@ along with the tables used to alter the 8x14 and 8x16 ROM fonts into
 ; Assembled with MASM
 ; By Michael Abrash
 ;
-stack   segment para stack ‘STACK'
+stack   segment para stack 'STACK'
         db      512 dup(?)
 stack   ends
 ;
@@ -478,16 +478,16 @@ GC_ROTATE               equ     3           ;GC data rotate/logical function
 GC_MODE                 equ     5           ;GC Mode register
 GC_BIT_MASK             equ     8           ;GC bit mask register index
 ;
-dseg    segment para common ‘DATA'
+dseg    segment para common 'DATA'
 TEST_TEXT_ROW           equ     69          ;row to display test text at
 TEST_TEXT_COL           equ     17          ;column to display test text at
 TEST_TEXT_COLOR         equ     0fh         ;high intensity white
 TestString      label   byte
-        db      ‘Hello, world!',0           ;test string to print.
+        db      'Hello, world!',0           ;test string to print.
 FontPointer     dd      ?                   ;font offset
 dseg    ends
 ;
-cseg    segment para public ‘CODE'
+cseg    segment para public 'CODE'
         assume  cs:cseg, ds:dseg
 start   proc    near
         mov     ax,dseg

--- a/src/chapter-27.md
+++ b/src/chapter-27.md
@@ -182,7 +182,7 @@ image.
 ;
 ; By Michael Abrash
 ;
-Stack   segment para stack ‘STACK'
+Stack   segment para stack 'STACK'
         db      512 dup(0)
 Stack   ends
 
@@ -194,7 +194,7 @@ GC_INDEX                                  equ     03ceh   ;Graphics Controller I
 GRAPHICS_MODE                             equ     5       ;index of Graphics Mode reg
 BIT_MASKequ     8       ;index of Bit Mask reg
 
-Data    segment para common ‘DATA'
+Data    segment para common 'DATA'
 ;
 ; Current location of "A" as it is animated across the screen.
 ;
@@ -221,7 +221,7 @@ AImage          label   byte
                 db      000h, 000h, 000h, 000h, 000h, 000h, 000h
 Data    ends
 
-Code    segment para public ‘CODE'
+Code    segment para public 'CODE'
         assume  cs:Code, ds:Data
 Start   proc    near
         mov     ax,Data
@@ -444,7 +444,7 @@ the CPU byte in write mode 2 to select the color in which to draw.
 ;
 ; By Michael Abrash
 ;
-Stack   segment para stack ‘STACK'
+Stack   segment para stack 'STACK'
         db      512 dup(0)
 Stack   ends
 
@@ -456,7 +456,7 @@ GC_INDEX              equ     03ceh   ;Graphics Controller Index reg
 GRAPHICS_MODE         equ     5       ;index of Graphics Mode reg
 BIT_MASK              equ     8       ;index of Bit Mask reg
 
-Data    segment para common ‘DATA'
+Data    segment para common 'DATA'
 Pattern0        db      16
                 db      0, 1, 2, 3, 4, 5, 6, 7, 8
                 db      9, 10, 11, 12, 13, 14, 15
@@ -468,7 +468,7 @@ Pattern3        db      9
                 db      1, 1, 1, 2, 2, 2, 4, 4, 4
 Data    ends
 
-Code    segment para public ‘CODE'
+Code    segment para public 'CODE'
         assume  cs:Code, ds:Data
 Start   proc    near
         mov     ax,Data
@@ -929,7 +929,7 @@ rewarding!) VGA to cover.
 ;
 ; By Michael Abrash
 ;
-Stack   segment para stack ‘STACK'
+Stack   segment para stack 'STACK'
         db      512 dup(0)
 Stack   ends
 
@@ -940,19 +940,19 @@ MAP_MASK        equ     2       ;index of Map Mask register
 GC_INDEX        equ     3ceh    ;Graphics Controller Index register
 READ_MAP        equ     4       ;index of Read Map register
 
-Data    segment para common ‘DATA'
+Data    segment para common 'DATA'
 
 GStrikeAnyKeyMsg0       label   byte
-        db      0dh, 0ah, ‘Graphics mode', 0dh, 0ah
-        db      ‘Strike any key to continue...', 0dh, 0ah, ‘$'
+        db      0dh, 0ah, 'Graphics mode', 0dh, 0ah
+        db      'Strike any key to continue...', 0dh, 0ah, '$'
 
 GStrikeAnyKeyMsg1       label   byte
-        db      0dh, 0ah, ‘Graphics mode again', 0dh, 0ah
-        db      ‘Strike any key to continue...', 0dh, 0ah, ‘$'
+        db      0dh, 0ah, 'Graphics mode again', 0dh, 0ah
+        db      'Strike any key to continue...', 0dh, 0ah, '$'
 
 TStrikeAnyKeyMsg        label   byte
-        db      0dh, 0ah, ‘Text mode', 0dh, 0ah
-        db      ‘Strike any key to continue...', 0dh, 0ah, ‘$'
+        db      0dh, 0ah, 'Text mode', 0dh, 0ah
+        db      'Strike any key to continue...', 0dh, 0ah, '$'
 
 Plane2Save      db      2000h dup (?)   ;save area for plane 2 data
                                         ; where font gets loaded
@@ -961,7 +961,7 @@ CharAttSave     db      4000 dup (?)    ;save area for memory wiped
                                         ; data in text mode
 Data    ends
 
-Code    segment para public ‘CODE'
+Code    segment para public 'CODE'
         assume  cs:Code, ds:Data
 Start   proc    near
         mov     ax,10h
@@ -1045,7 +1045,7 @@ FillBitMap:
         mov     ax,TEXT_SEGMENT
         mov     es,ax
         sub     di,di
-        mov     al,‘.'          ;fill character
+        mov     al,'.'          ;fill character
         mov     ah,7            ;fill attribute
         mov     cx,4000/2       ;length of one text screen in words
         rep stosw

--- a/src/chapter-29.md
+++ b/src/chapter-29.md
@@ -81,19 +81,19 @@ READ_MAP                    equ   4                ;Read Map register index in G
 DISPLAYED_SCREEN_SIZE       equ  (640/8)*350       ;# of displayed bytes per plane in a
                                                    ; hi-res graphics screen
 ;
-stack      segment para stack ‘STACK'
+stack      segment para stack 'STACK'
                  db                  512 dup (?)
 stack      ends
 ;
-Data       segment     word ‘DATA'
-SampleText       db    ‘This is bit-mapped text, drawn in hi-res '
-                 db    ‘EGA graphics mode 10h.', 0dh, 0ah, 0ah
-                 db    ‘Saving the screen (including this text)...'
-                 db    0dh, 0ah, ‘$'
-Filename         db    ‘SNAPSHOT.SCR',0   ;name of file we're saving to
-ErrMsg1          db    ‘*** Couldn't open SNAPSHOT.SCR ***',0dh,0ah,‘$'
-ErrMsg2          db    ‘*** Error writing to SNAPSHOT.SCR ***',0dh,0ah,‘$'
-WaitKeyMsg       db    0dh, 0ah, ‘Done. Press any key to end...',0dh,0ah,‘$'
+Data       segment     word 'DATA'
+SampleText       db    'This is bit-mapped text, drawn in hi-res '
+                 db    'EGA graphics mode 10h.', 0dh, 0ah, 0ah
+                 db    'Saving the screen (including this text)...'
+                 db    0dh, 0ah, '$'
+Filename         db    'SNAPSHOT.SCR',0   ;name of file we're saving to
+ErrMsg1          db    '*** Couldn't open SNAPSHOT.SCR ***',0dh,0ah,'$'
+ErrMsg2          db    '*** Error writing to SNAPSHOT.SCR ***',0dh,0ah,'$'
+WaitKeyMsg       db    0dh, 0ah, 'Done. Press any key to end...',0dh,0ah,'$'
 Handle           dw    ?                           ;handle of file we're saving to
 Plane            db    ?                           ;plane being read
 Data  ends
@@ -214,15 +214,15 @@ MAP_MASK                    equ   2               ;Map Mask register index in SC
 DISPLAYED_SCREEN_SIZE       equ  (640/8)*350      ;# of displayed bytes per plane in a
                                                   ; hi-res graphics screen
 ;
-stack      segment para stack ‘STACK'
+stack      segment para stack 'STACK'
                  db              512 dup (?)
 stack      ends
 ;
-Data       segment     word ‘DATA'
-Filename         db          ‘SNAPSHOT.SCR',0   ;name of file we're restoring from
-ErrMsg1          db          ‘*** Couldn'‘t open SNAPSHOT.SCR ***',0dh,0ah,‘$'
-ErrMsg2          db          ‘*** Error reading from SNAPSHOT.SCR ***',0dh,0ah,‘$'
-WaitKeyMsg       db          0dh, 0ah, ‘Done. Press any key to end...',0dh,0ah,‘$'
+Data       segment     word 'DATA'
+Filename         db          'SNAPSHOT.SCR',0   ;name of file we're restoring from
+ErrMsg1          db          '*** Couldn''t open SNAPSHOT.SCR ***',0dh,0ah,'$'
+ErrMsg2          db          '*** Error reading from SNAPSHOT.SCR ***',0dh,0ah,'$'
+WaitKeyMsg       db          0dh, 0ah, 'Done. Press any key to end...',0dh,0ah,'$'
 Handle           dw          ?                  ;handle of file we're restoring from
 Plane            db          ?                  ;plane being written
 Data       ends
@@ -529,16 +529,16 @@ BAR_HEIGHT             equ  14           ;height of each bar
 TOP_BAR                equ  BAR_HEIGHT*6 ;start the bars down a bit to
                                          ; leave room for text
 ;
-stack    segment para stack ‘STACK'
+stack    segment para stack 'STACK'
               db                  512 dup (?)
 stack    ends
 ;
-Data     segment    word ‘DATA'
-KeyMsg   db         ‘Press any key to see the next color set. '
-         db         ‘There are 64 color sets in all.'
+Data     segment    word 'DATA'
+KeyMsg   db         'Press any key to see the next color set. '
+         db         'There are 64 color sets in all.'
          db         0dh, 0ah, 0ah, 0ah, 0ah
-         db         13 dup (‘ '), ‘Attribute'
-         db         38 dup (‘ '), ‘Color$'
+         db         13 dup (' '), 'Attribute'
+         db         38 dup (' '), 'Color$'
 ;
 ; Used to label the attributes of the color bars.
 ;
@@ -546,23 +546,23 @@ AttributeNumbers    label byte
 x=         0
            rept     16
 if x lt 10
-           db       ‘0', x+‘0', ‘h', 0ah, 8, 8, 8
+           db       '0', x+'0', 'h', 0ah, 8, 8, 8
 else
-           db       ‘0', x+‘A'-10, ‘h', 0ah, 8, 8, 8
+           db       '0', x+'A'-10, 'h', 0ah, 8, 8, 8
 endif
 x=         x+1
            endm
-           db       ‘$'
+           db       '$'
 ;
 ; Used to label the colors of the color bars. (Color values are
 ; filled in on the fly.)
 ;
 ColorNumbers label byte
            rept    16
-           db      ‘000h', 0ah, 8, 8, 8, 8
+           db      '000h', 0ah, 8, 8, 8, 8
            endm
 COLOR_ENTRY_LENGTH equ ($-ColorNumbers)/16
-           db      ‘$'
+           db      '$'
 ;
 CurrentColor db ?
 ;
@@ -718,10 +718,10 @@ BarUp         endp
 BinToHexDigit proc        near
               cmp         al,9
               ja                IsHex
-              add         al,‘0'
+              add         al,'0'
               ret
 IsHex:
-              add         al,‘A'-10
+              add         al,'A'-10
               ret
 BinToHexDigit endp
 ;
@@ -819,16 +819,16 @@ WAIT_KEY macro
               int      21h
               endm
 ;
-stack         segment para stack ‘STACK'
+stack         segment para stack 'STACK'
               db 512 dup (?)
 stack         ends
 ;
-Data  segment   word   ‘DATA'
-SampleText      db     ‘This is bit-mapped text, drawn in hi-res '
-                db     ‘EGA graphics mode 10h.', 0dh, 0ah, 0ah
-                db     ‘Press any key to blank the screen, then '
-                db     ‘any key to unblank it,', 0dh, 0ah
-                db     ‘then any key to end.$'
+Data  segment   word   'DATA'
+SampleText      db     'This is bit-mapped text, drawn in hi-res '
+                db     'EGA graphics mode 10h.', 0dh, 0ah, 0ah
+                db     'Press any key to blank the screen, then '
+                db     'any key to unblank it,', 0dh, 0ah
+                db     'then any key to end.$'
 Data        ends
 ;
 Code        segment

--- a/src/chapter-32.md
+++ b/src/chapter-32.md
@@ -148,7 +148,7 @@ WORD_OUTS_OK    equ    1           ;set to 0 to assemble for
                                    ; computers that can't handle
                                    ; word outs to indexed VGA registers
 ;
-_DATA segment public byte ‘DATA'
+_DATA segment public byte 'DATA'
 ;
 ; 360x480 256-color mode CRT Controller register settings.
 ; (Courtesy of John Bridges.)
@@ -188,7 +188,7 @@ else
 endif
       endm
 ;
-_TEXTsegment byte public ‘CODE'
+_TEXTsegment byte public 'CODE'
        assumecs:_TEXT, ds:_DATA
 ;
 ; Sets up 360x480 256-color mode.

--- a/src/chapter-43.md
+++ b/src/chapter-43.md
@@ -263,7 +263,7 @@ WORD_OUTS_OK    equ     1       ;set to 0 to assemble for
                                 ; handle word outs to
                                 ; indexed VGA regs
                                 ;
-stack segment para stack ‘STACK'
+stack segment para stack 'STACK'
         db      512 dup (?)
 stack ends
 ;
@@ -297,7 +297,7 @@ PlaneSelect db  ?       ;mask to select plane to
                         ; word-aligned)
 ObjectStructure ends
 ;
-Data segment    word ‘DATA'
+Data segment    word 'DATA'
 ;
 ; Palette settings to give plane 0 precedence, followed by
 ; planes 1, 2, and 3. Plane 3 has the lowest precedence (is

--- a/src/chapter-50.md
+++ b/src/chapter-50.md
@@ -725,10 +725,10 @@ void main() {
          switch (getch()) {
             case 0x1B:     /* Esc to exit */
                Done = 1; break;
-            case ‘A': case ‘a':      /* away (-Z) */
+            case 'A': case 'a':      /* away (-Z) */
                PolyWorldXform[2][3] -= 3.0; break;
-            case ‘T':      /* towards (+Z). Don't allow to get too */
-            case ‘t':      /* close, so Z clipping isn't needed */
+            case 'T':      /* towards (+Z). Don't allow to get too */
+            case 't':      /* close, so Z clipping isn't needed */
                if (PolyWorldXform[2][3] < -40.0)
                      PolyWorldXform[2][3] += 3.0; break;
             case 0:     /* extended code */

--- a/src/chapter-51.md
+++ b/src/chapter-51.md
@@ -314,25 +314,25 @@ void main() {
          switch (getch()) {
             case 0x1B:     /* Esc to exit */
                Done = 1; break;
-            case ‘A': case ‘a':      /* away (-Z) */
+            case 'A': case 'a':      /* away (-Z) */
                CubeWorldXform[2][3] -= 3.0; RecalcXform = 1; break;
-            case ‘T':      /* towards (+Z). Don't allow to get too */
-            case ‘t':      /* close, so Z clipping isn't needed */
+            case 'T':      /* towards (+Z). Don't allow to get too */
+            case 't':      /* close, so Z clipping isn't needed */
                if (CubeWorldXform[2][3] < -40.0) {
                      CubeWorldXform[2][3] += 3.0;
                      RecalcXform = 1;
                }
                break;
-            case ‘4':         /* rotate clockwise around Y */
+            case '4':         /* rotate clockwise around Y */
                AppendRotationY(CubeWorldXform, -ROTATION);
                RecalcXform=1; break;
-            case ‘6':         /* rotate counterclockwise around Y */
+            case '6':         /* rotate counterclockwise around Y */
                AppendRotationY(CubeWorldXform, ROTATION);
                RecalcXform=1; break;
-            case ‘8':         /* rotate clockwise around X */
+            case '8':         /* rotate clockwise around X */
                AppendRotationX(CubeWorldXform, -ROTATION);
                RecalcXform=1; break;
-            case ‘2':         /* rotate counterclockwise around X */
+            case '2':         /* rotate counterclockwise around X */
                AppendRotationX(CubeWorldXform, ROTATION);
                RecalcXform=1; break;
             case 0:     /* extended code */

--- a/src/chapter-55.md
+++ b/src/chapter-55.md
@@ -451,9 +451,9 @@ but is considerably more difficult to apply.
  LineWidthBytes  dw ?                ;offset from one scan line to the next
  FontPtr         dd ?                ;pointer to font with which to draw
  SampleString    label              byte
-       db  ‘ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-       db  ‘abcdefghijklmnopqrstuvwxyz'
-       db  ‘0123456789!@#$%^&*(),<.>/?;:',0
+       db  'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+       db  'abcdefghijklmnopqrstuvwxyz'
+       db  '0123456789!@#$%^&*(),<.>/?;:',0
 
       .code
  start:


### PR DESCRIPTION
Mostly a `sed` job with some customizations to not change the nice quotes for prose text.

    sed -i '' -e "s/‘/'/g" src/*.md
    sed -i '' -e "s/#146;/'/g" src/*.md