### PR TITLE
Add a GitHub workflow to build the book

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build with Pandoc
+on:
+  - push
+  - pull_request
+
+jobs:
+  pandoc-build:
+    name: Pandoc build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Pandoc
+        run: |
+          sudo apt update
+          sudo apt install pandoc
+
+      - name: Check out the target branch
+        uses: actions/checkout@v2
+      - name: Build the book
+        # Kindle .mobi output suppressed because the Amazon KindleGen tool is
+        # no longer available.
+        run: make html epub
+
+      - name: Upload the HTML book
+        uses: actions/upload-artifact@v2
+        with:
+          name: black-book-html
+          path: out/html/
+      - name: Upload the EPUB book
+        uses: actions/upload-artifact@v2
+        with:
+          name: black-book-epub
+          path: out/black-book.epub


### PR DESCRIPTION
This PR adds a GitHub workflow definition which builds the book (via [GitHub Actions](https://github.com/features/actions)) whenever new commits are pushed and for every pull request. The HTML and EPUB build artifacts are then made available for download. For an example, see [this action run](https://github.com/MrDOS/abrash-black-book/actions/runs/729021902) in my fork of the repository.