### PR TITLE
Correct typo in Chapter 9

### DIFF
--- a/src/chapter-09.md
+++ b/src/chapter-09.md
@@ -271,7 +271,7 @@ other operand.
 (There's a minimum execution time on this trick; below 3 significant
 multiplier bits, no additional cycles are saved.) For example,
 multiplication of 32,767 times 1 is 12 cycles faster than multiplication
-of 1 times 32,727.
+of 1 times 32,767.
 
 Choosing the right operand as the multiplier can work wonders. According
 to published specs, the 386 takes 38 cycles to multiply by a multiplier


### PR DESCRIPTION
1 * 32,767 is faster than 32,767 * 1.
The point is which operand is smaller.